### PR TITLE
fix(default export): add backwards compatibility

### DIFF
--- a/src/Switch.ts
+++ b/src/Switch.ts
@@ -26,12 +26,12 @@ class SwitchMatched<T, K> implements ISwitch<T, K> {
  * Switch becomes a kind of Left and holds the value until it reaches the .default call. If
  * matching didn't happen for all cases, the value of the .default argument is returned instead.
  */
-export class Switch<T, K extends []> implements ISwitch<T, K> {
+export class Switch<T, K extends any[]> implements ISwitch<T, K> {
   /**
    * Pointer interface for lifting a value into Switch.
    */
-  public static for<T, K extends [] = []>(x: T): ISwitch<T, K> {
-    return new Switch<T, K>(x);
+  public static for<T, K = []>(x: T): ISwitch<T, K extends [] ? K : [K]> {
+    return new Switch<T, K extends [] ? K : [K]>(x);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,6 @@ export * from "./TPredicateFunction";
 /**
  * Pointer interface for lifting value provided as an argument to Switch.
  */
-export default function<T, K extends []>(x: T): ISwitch<T, K> {
+export default function test<T, K = []>(x: T): ISwitch<T, K extends [] ? K : [K]> {
   return Switch.for<T, K>(x);
 }


### PR DESCRIPTION
Second generic type can be provided as a single value